### PR TITLE
Add support forWIP:  injecting the UUID and git commit id of the notebook …

### DIFF
--- a/inject-uuid/README.md
+++ b/inject-uuid/README.md
@@ -1,10 +1,8 @@
-# Environment Life
-For environments where the Jupyter container a user is using is deleted on a
-regular basis, you can set an environment variable to have the expiration date
-and time displayed to the user in the status bar at the bottom of Juptyer Lab.
-Simply set NBGALLERY_CREATION_TIME to a UTC timestamp in the following format:
+# Inject UUID
+If the user is running a notebook loaded from NBGallery, when initially opened
+this plugin will inject the NBGallery Notebook UUID and the Commit ID of the revision
+being run into the kernel's environment.  
 
-export NBGALLERY_TERMINATION_TIME=`date --date='14 days' +'%Y-%m-%d %H:%M:%S'`
+This currently works for Python and Ruby only.
 
-You can pass this in to the container or have a startup script mounted in
-/usr/local/bin/start-notebook.d/ which sets this environment variable.
+The values will be in 'NBGALLERY_UUID' and 'NBGALLERY_GIT_COMMIT_ID'

--- a/inject-uuid/README.md
+++ b/inject-uuid/README.md
@@ -1,0 +1,10 @@
+# Environment Life
+For environments where the Jupyter container a user is using is deleted on a
+regular basis, you can set an environment variable to have the expiration date
+and time displayed to the user in the status bar at the bottom of Juptyer Lab.
+Simply set NBGALLERY_CREATION_TIME to a UTC timestamp in the following format:
+
+export NBGALLERY_TERMINATION_TIME=`date --date='14 days' +'%Y-%m-%d %H:%M:%S'`
+
+You can pass this in to the container or have a startup script mounted in
+/usr/local/bin/start-notebook.d/ which sets this environment variable.

--- a/inject-uuid/package.json
+++ b/inject-uuid/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@jupyterlab-nbgallery/inject-uuid",
+  "version": "0.2.0",
+  "description": "Inject the notebook UUID into the kernel.",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
+  "homepage": "https://github.com/nbgallery/lab-extensions",
+  "bugs": {
+    "url": "https://github.com/nbgallery/lab-extensions/issues"
+  },
+  "license": "MIT",
+  "author": "Team@NBG",
+  "files": [
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nbgallery/lab-extensions"
+  },
+  "scripts": {
+    "build": "jlpm run build:lib",
+    "build:labextension": "mkdir -p ../labextension && mkdir -p labextension && cd labextension && npm pack .. && cp *.tgz ../../labextension/",
+    "build:lib": "tsc",
+    "build:all": "jlpm run build:labextension",
+    "clean": "jlpm run clean:lib",
+    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+    "clean:labextension": "rimraf labextension",
+    "install-ext": "jupyter labextension install . --no-build",
+    "prepare": "jlpm run clean && jlpm run build",
+    "eslint": "eslint . --ext .ts,.tsx --fix",
+    "eslint:check": "eslint . --ext .ts,.tsx",
+    "watch": "tsc -w"
+  },
+  "dependencies": {
+    "@jupyterlab/application": "^3.0.0",
+    "@jupyterlab/settingregistry": "^3.0.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.21.0",
+    "@typescript-eslint/parser": "^2.21.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-jsdoc": "^22.0.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-react": "^7.18.3",
+    "glob": "latest",
+    "rimraf": "^3.0.2",
+    "typescript": "~3.7.5"
+  },
+  "jupyterlab": {
+    "extension": true
+  }
+}

--- a/inject-uuid/src/index.ts
+++ b/inject-uuid/src/index.ts
@@ -1,0 +1,42 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+
+import {
+  NotebookPanel, INotebookTracker
+} from '@jupyterlab/notebook';
+
+
+const extension: JupyterFrontEndPlugin<void> = {
+  id: "@jupyterlab-nbgallery/inject-uuid",
+  autoStart: true,
+  requires: [INotebookTracker],
+  activate: (
+    app: JupyterFrontEnd,
+    notebooks: INotebookTracker
+  ) => {
+    notebooks.forEach(injectUUID)
+    notebooks.widgetAdded.connect((_, a) => injectUUID(a))
+  },
+};
+function injectUUID(panel: NotebookPanel): void {
+  panel.sessionContext.ready.then(() => {
+      let gallery_metadata :any;
+      gallery_metadata = panel.model.metadata.toJSON()["gallery"];
+      if(gallery_metadata && gallery_metadata['uuid']){
+        let kernel = panel.sessionContext.session.kernel;
+        console.log(kernel);
+        if(kernel.name == "python" || kernel.name == "python3"){
+          kernel.requestExecute({code:"import os; os.environ['NBGALLERY_UUID']='"+gallery_metadata['uuid']+"'; os.environ['NBGALLERY_GIT_COMMIT_ID']='"+gallery_metadata['git_commit_id']+"';",silent: true,stop_on_error: true});
+        }
+        if(kernel.name == "ruby"){
+          kernel.requestExecute({code:"ENV['NBGALLERY_UUID']='"+gallery_metadata['uuid']+"'",silent: true,stop_on_error: true});
+          kernel.requestExecute({code:"ENV['NBGALLERY_GIT_COMMIT_ID']='"+gallery_metadata['git_commit_id']+"'",silent: true,stop_on_error: true});
+        }
+      }
+  });
+}
+
+export default extension;

--- a/inject-uuid/tsconfig.json
+++ b/inject-uuid/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": false,
+    "target": "es2017",
+    "types": []
+  },
+  "include": ["src/*"]
+}

--- a/jupyterlab_nbgallery/_version.py
+++ b/jupyterlab_nbgallery/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 3, 0)
+version_info = (0, 3, 1)
 __version__ = ".".join(map(str, version_info))

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
       "environment-life",
       "autodownload",
       "gallerymenu",
-      "instrumentation"
+      "instrumentation",
+      "inject-uuid"
     ]
   },
   "devDependencies": {

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ jstargets = [
     pjoin(HERE, "autodownload", "lib", "index.js"),
     pjoin(HERE, "gallerymenu", "lib", "index.js"),
     pjoin(HERE, "instrumentation", "lib", "index.js"),
+    pjoin(HERE, "inject-uuid", "lib", "index.js"),
 ]
 
 package_data_spec = {


### PR DESCRIPTION
…into the environment

Works for Ruby and Python so far.

Closes #15 