### PR TITLE
Fix ajax request for downloadReplace

### DIFF
--- a/gallerymenu/src/index.ts
+++ b/gallerymenu/src/index.ts
@@ -315,7 +315,11 @@ class galleryMenu {
     );
     try {
       let response = await $.ajax({
-        url: url
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        url: url,
+        cache: false,
+        xhrFields: { withCredentials: true }
       });
       let notebook_content = JSON.parse(response);
       if (gallery_metadata["link"]) {


### PR DESCRIPTION
When Running "check for changes" -> "download and replace local", we get a 400 CORS error, and we see that no cookies are sent and the accept type is set to `*/*`. The call for the `downloadReplace` seems to be very basic (just setting the url) compared to other functions which populate more of the fields, notably the `headers` and `xhrFields`.

Note, we noticed this error is browser-dependent. On Chrome, the request is fine, but on FireFox we noticed the 400 Error.